### PR TITLE
Update Pulumi deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     },
     "dependencies": {
         "@octokit/rest": "^15.9.4",
-        "@pulumi/awsx": "^0.18.0",
-        "@pulumi/pulumi": "^1.0.0-rc",
-        "@pulumi/random": "^1.0.0-rc"
+        "@pulumi/awsx": "0.18.14",
+        "@pulumi/pulumi": "1.7.1",
+        "@pulumi/random": "1.4.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     },
     "dependencies": {
         "@octokit/rest": "^15.9.4",
-        "@pulumi/awsx": "0.18.14",
-        "@pulumi/pulumi": "1.7.1",
-        "@pulumi/random": "1.4.0"
+        "@pulumi/awsx": "^0.18.14",
+        "@pulumi/pulumi": "^1.7.1",
+        "@pulumi/random": "^1.4.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dependencies": {
         "@octokit/rest": "^15.9.4",
         "@pulumi/awsx": "^0.18.14",
-        "@pulumi/pulumi": "^1.7.1",
+        "@pulumi/pulumi": "^1.8.1",
         "@pulumi/random": "^1.4.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,26 +68,26 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
-"@pulumi/aws@^1.0.0-beta":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-1.0.0-rc.1.tgz#b2e875aa175863eb06dc69e195a425abc0ef5b7e"
-  integrity sha512-Ms95q1kfuBctbz4htirz3rpVI1ObJWx8bkhkMgIywm+DtPtUz1PaPxTxaQmxzhYnI9BvvCaFzzZ9rGH8qVyaKw==
+"@pulumi/aws@^1.0.0":
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/aws/-/aws-1.17.0.tgz#3d8a00a5e1c488c2e409d134b4570adf67b40580"
+  integrity sha512-x+NQJKoeMMfwrhxtYbrmpBFMpH/dgxGky3tRYw5l7ZDVtaBVU2rdM4pXnM4FReCZHXNv5oTaQGeeWGizivazGA==
   dependencies:
-    "@pulumi/pulumi" "^1.0.0-beta"
+    "@pulumi/pulumi" "^1.0.0"
     aws-sdk "^2.0.0"
     builtin-modules "3.0.0"
     mime "^2.0.0"
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/awsx@^0.18.0":
-  version "0.18.10"
-  resolved "https://registry.yarnpkg.com/@pulumi/awsx/-/awsx-0.18.10.tgz#bc72849024ae6e74a29b5ab7fc26cb2eab2f61a1"
-  integrity sha512-O/xoftGzOKGMi/A9ctzIvhoFSpjY+RDnkb0RgvhMzgnVif2GbCrjNrFafTcvmC0v7fR2o0PbuKJmln7uktBYDQ==
+"@pulumi/awsx@0.18.14":
+  version "0.18.14"
+  resolved "https://registry.yarnpkg.com/@pulumi/awsx/-/awsx-0.18.14.tgz#798f02648971e533936637427387a723de733767"
+  integrity sha512-2etPn1fCPSk+xpIow9vqS398SVmNZlmJe3gP7icWSZeaON8ActfYE/89JEWLSSkWkzc7h8P+LavkLg2sYWmGnw==
   dependencies:
-    "@pulumi/aws" "^1.0.0-beta"
+    "@pulumi/aws" "^1.0.0"
     "@pulumi/docker" "^0.17.3"
-    "@pulumi/pulumi" "^1.0.0-beta"
+    "@pulumi/pulumi" "^1.0.0"
     "@types/aws-lambda" "^8.10.23"
     deasync "^0.1.15"
     mime "^2.0.0"
@@ -100,7 +100,47 @@
     "@pulumi/pulumi" "^1.0.0-beta"
     semver "^5.4.0"
 
-"@pulumi/pulumi@^1.0.0-beta", "@pulumi/pulumi@^1.0.0-rc":
+"@pulumi/pulumi@1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-1.7.1.tgz#7edb4c980c351c9f9b9e15e8e50746b2f9b2e43a"
+  integrity sha512-kyJ7zs9FlgLEVygeNbOv361T6LFsBow2ZihlMAcgsxzNxsP90wBiOGqsliyymznX03A6cHt4llTqSIH4ONeXKw==
+  dependencies:
+    "@pulumi/query" "^0.3.0"
+    deasync "^0.1.15"
+    google-protobuf "^3.5.0"
+    grpc "1.24.2"
+    minimist "^1.2.0"
+    normalize-package-data "^2.4.0"
+    protobufjs "^6.8.6"
+    read-package-tree "^5.3.1"
+    require-from-string "^2.0.1"
+    semver "^6.1.0"
+    source-map-support "^0.4.16"
+    ts-node "^7.0.0"
+    typescript "=3.6.3"
+    upath "^1.1.0"
+
+"@pulumi/pulumi@^1.0.0":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-1.8.1.tgz#02d1a2b98e1c873792868d378360a569454b6c01"
+  integrity sha512-YECXh3TRCl21QYpvUrzGDGBVqZBr3V053x1chXnt/7+FgwxM5M1cpH3T7kQX44+z7crvIqvQ7FbngNpgCHKa1Q==
+  dependencies:
+    "@pulumi/query" "^0.3.0"
+    deasync "^0.1.15"
+    google-protobuf "^3.5.0"
+    grpc "1.24.2"
+    minimist "^1.2.0"
+    normalize-package-data "^2.4.0"
+    protobufjs "^6.8.6"
+    read-package-tree "^5.3.1"
+    require-from-string "^2.0.1"
+    semver "^6.1.0"
+    source-map-support "^0.4.16"
+    ts-node "^8.5.4"
+    typescript "~3.7.3"
+    upath "^1.1.0"
+
+"@pulumi/pulumi@^1.0.0-beta":
   version "1.0.0-rc.1"
   resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-1.0.0-rc.1.tgz#f04dbd8506d13502e217b8273a44d0ef98bafd48"
   integrity sha512-eapuDr05WIC5qvGsRlTUBc/o5LPpUGIo/eWDVxM9OjqbX7kfWDWl5jSXzJet2ZyKd0oMYx+asubz0JnQ8ib64w==
@@ -125,22 +165,35 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
-"@pulumi/random@^1.0.0-rc":
-  version "1.0.0-rc.1"
-  resolved "https://registry.yarnpkg.com/@pulumi/random/-/random-1.0.0-rc.1.tgz#10334ca6aa95a1542b17e2d209f81da4ea00bd45"
-  integrity sha512-cP8iG4X05IO0sIiNDoQL1sjQfwO6r4ku2J0uPm0j5FF65ea086EKWf7PuIxAzki8KoKP7aFTDP3zSPnXEYzzjA==
+"@pulumi/random@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@pulumi/random/-/random-1.4.0.tgz#233f831cae0f14d96ac8bd4189ea30eff904f93d"
+  integrity sha512-7HgVLDV4k3k8r9DKldz78n3Js7Q6gFrQhfO6kFZt5rAFp/f1j2sikzvhts3xM46xheEcEYCvnhb+BhxAB8vA8Q==
   dependencies:
-    "@pulumi/pulumi" "^1.0.0-beta"
+    "@pulumi/pulumi" "^1.0.0"
 
 "@types/aws-lambda@^8.10.23":
   version "8.10.31"
   resolved "https://registry.yarnpkg.com/@types/aws-lambda/-/aws-lambda-8.10.31.tgz#f34c42412e59824efa21717c71024f7d04405b51"
   integrity sha512-xcmOvzVILQoex1oR+vjKnBP3OJn+g92r3yVzeTSmRgLQwBvSOghRPRSx3rVMQivLzAIR6atxlVu3AV9bxc/hQw==
 
-"@types/long@^4.0.0":
+"@types/bytebuffer@^5.0.40":
+  version "5.0.40"
+  resolved "https://registry.yarnpkg.com/@types/bytebuffer/-/bytebuffer-5.0.40.tgz#d6faac40dcfb09cd856cdc4c01d3690ba536d3ee"
+  integrity sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==
+  dependencies:
+    "@types/long" "*"
+    "@types/node" "*"
+
+"@types/long@*", "@types/long@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.0.tgz#719551d2352d301ac8b81db732acb6bdc28dbdef"
   integrity sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==
+
+"@types/node@*":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.2.tgz#fe94285bf5e0782e1a9e5a8c482b1c34465fa385"
+  integrity sha512-B8emQA1qeKerqd1dmIsQYnXi+mmAzTB7flExjmy5X1aVAKFNNNDubkavwR13kR6JnpeLp3aLoJhwn9trWPAyFQ==
 
 "@types/node@^10.1.0":
   version "10.14.16"
@@ -195,6 +248,11 @@ are-we-there-yet@~1.1.2:
   dependencies:
     delegates "^1.0.0"
     readable-stream "^2.0.6"
+
+arg@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.2.tgz#e70c90579e02c63d80e3ad4e31d8bfdb8bd50064"
+  integrity sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -447,6 +505,11 @@ diff@^3.1.0, diff@^3.2.0:
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
 
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
+
 es-abstract@^1.5.1:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.13.0.tgz#ac86145fdd5099d8dd49558ccba2eaf9b88e24e9"
@@ -561,6 +624,18 @@ grpc@1.21.1:
     lodash.clone "^4.5.0"
     nan "^2.13.2"
     node-pre-gyp "^0.13.0"
+    protobufjs "^5.0.3"
+
+grpc@1.24.2:
+  version "1.24.2"
+  resolved "https://registry.yarnpkg.com/grpc/-/grpc-1.24.2.tgz#76d047bfa7b05b607cbbe3abb99065dcefe0c099"
+  integrity sha512-EG3WH6AWMVvAiV15d+lr+K77HJ/KV/3FvMpjKjulXHbTwgDZkhkcWbwhxFAoTdxTkQvy0WFcO3Nog50QBbHZWw==
+  dependencies:
+    "@types/bytebuffer" "^5.0.40"
+    lodash.camelcase "^4.3.0"
+    lodash.clone "^4.5.0"
+    nan "^2.13.2"
+    node-pre-gyp "^0.14.0"
     protobufjs "^5.0.3"
 
 has-ansi@^2.0.0:
@@ -784,6 +859,14 @@ minipass@^2.2.1, minipass@^2.3.5:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
+minipass@^2.8.6:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.9.0.tgz#e713762e7d3e32fed803115cf93e04bca9fcc9a6"
+  integrity sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==
+  dependencies:
+    safe-buffer "^5.1.2"
+    yallist "^3.0.0"
+
 minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
@@ -846,6 +929,22 @@ node-pre-gyp@^0.13.0:
     rimraf "^2.6.1"
     semver "^5.3.0"
     tar "^4"
+
+node-pre-gyp@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.14.0.tgz#9a0596533b877289bcad4e143982ca3d904ddc83"
+  integrity sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==
+  dependencies:
+    detect-libc "^1.0.2"
+    mkdirp "^0.5.1"
+    needle "^2.2.1"
+    nopt "^4.0.1"
+    npm-packlist "^1.1.6"
+    npmlog "^4.0.2"
+    rc "^1.2.7"
+    rimraf "^2.6.1"
+    semver "^5.3.0"
+    tar "^4.4.2"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -1252,6 +1351,19 @@ tar@^4:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
+tar@^4.4.2:
+  version "4.4.13"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.13.tgz#43b364bc52888d555298637b10d60790254ab525"
+  integrity sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==
+  dependencies:
+    chownr "^1.1.1"
+    fs-minipass "^1.2.5"
+    minipass "^2.8.6"
+    minizlib "^1.2.1"
+    mkdirp "^0.5.0"
+    safe-buffer "^5.1.2"
+    yallist "^3.0.3"
+
 ts-node@^7.0.0:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-7.0.1.tgz#9562dc2d1e6d248d24bc55f773e3f614337d9baf"
@@ -1265,6 +1377,17 @@ ts-node@^7.0.0:
     mkdirp "^0.5.1"
     source-map-support "^0.5.6"
     yn "^2.0.0"
+
+ts-node@^8.5.4:
+  version "8.5.4"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-8.5.4.tgz#a152add11fa19c221d0b48962c210cf467262ab2"
+  integrity sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==
+  dependencies:
+    arg "^4.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    source-map-support "^0.5.6"
+    yn "^3.0.0"
 
 tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
@@ -1293,10 +1416,20 @@ tsutils@^2.12.1:
   dependencies:
     tslib "^1.8.1"
 
+typescript@=3.6.3:
+  version "3.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
+  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+
 typescript@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
   integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
+
+typescript@~3.7.3:
+  version "3.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.4.tgz#1743a5ec5fef6a1fa9f3e4708e33c81c73876c19"
+  integrity sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==
 
 upath@^1.1.0:
   version "1.1.2"
@@ -1405,3 +1538,8 @@ yn@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
   integrity sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=
+
+yn@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,7 +80,7 @@
     read-package-tree "^5.2.1"
     resolve "^1.7.1"
 
-"@pulumi/awsx@0.18.14":
+"@pulumi/awsx@^0.18.14":
   version "0.18.14"
   resolved "https://registry.yarnpkg.com/@pulumi/awsx/-/awsx-0.18.14.tgz#798f02648971e533936637427387a723de733767"
   integrity sha512-2etPn1fCPSk+xpIow9vqS398SVmNZlmJe3gP7icWSZeaON8ActfYE/89JEWLSSkWkzc7h8P+LavkLg2sYWmGnw==
@@ -100,27 +100,7 @@
     "@pulumi/pulumi" "^1.0.0-beta"
     semver "^5.4.0"
 
-"@pulumi/pulumi@1.7.1":
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-1.7.1.tgz#7edb4c980c351c9f9b9e15e8e50746b2f9b2e43a"
-  integrity sha512-kyJ7zs9FlgLEVygeNbOv361T6LFsBow2ZihlMAcgsxzNxsP90wBiOGqsliyymznX03A6cHt4llTqSIH4ONeXKw==
-  dependencies:
-    "@pulumi/query" "^0.3.0"
-    deasync "^0.1.15"
-    google-protobuf "^3.5.0"
-    grpc "1.24.2"
-    minimist "^1.2.0"
-    normalize-package-data "^2.4.0"
-    protobufjs "^6.8.6"
-    read-package-tree "^5.3.1"
-    require-from-string "^2.0.1"
-    semver "^6.1.0"
-    source-map-support "^0.4.16"
-    ts-node "^7.0.0"
-    typescript "=3.6.3"
-    upath "^1.1.0"
-
-"@pulumi/pulumi@^1.0.0":
+"@pulumi/pulumi@^1.0.0", "@pulumi/pulumi@^1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@pulumi/pulumi/-/pulumi-1.8.1.tgz#02d1a2b98e1c873792868d378360a569454b6c01"
   integrity sha512-YECXh3TRCl21QYpvUrzGDGBVqZBr3V053x1chXnt/7+FgwxM5M1cpH3T7kQX44+z7crvIqvQ7FbngNpgCHKa1Q==
@@ -165,7 +145,7 @@
   resolved "https://registry.yarnpkg.com/@pulumi/query/-/query-0.3.0.tgz#f496608e86a18c3dd31b6c533408e2441c29071d"
   integrity sha512-xfo+yLRM2zVjVEA4p23IjQWzyWl1ZhWOGobsBqRpIarzLvwNH/RAGaoehdxlhx4X92302DrpdIFgTICMN4P38w==
 
-"@pulumi/random@1.4.0":
+"@pulumi/random@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@pulumi/random/-/random-1.4.0.tgz#233f831cae0f14d96ac8bd4189ea30eff904f93d"
   integrity sha512-7HgVLDV4k3k8r9DKldz78n3Js7Q6gFrQhfO6kFZt5rAFp/f1j2sikzvhts3xM46xheEcEYCvnhb+BhxAB8vA8Q==
@@ -1415,11 +1395,6 @@ tsutils@^2.12.1:
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.27.2.tgz#60ba88a23d6f785ec4b89c6e8179cac9b431f1c7"
   dependencies:
     tslib "^1.8.1"
-
-typescript@=3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
 
 typescript@^3.0.0:
   version "3.6.2"


### PR DESCRIPTION
Node8 has reached EOL on AWS Lambda. Updating the `@pulumi/awsx` npm package to the latest will set the runtime version by default to [Node12 runtime](https://github.com/pulumi/pulumi-aws/blob/95178aac2d85dbbfef957c9ebd89eb550357cd68/sdk/nodejs/lambda/lambdaMixins.ts#L320).